### PR TITLE
Builds on CSS for playlist page

### DIFF
--- a/styles/playlist.css
+++ b/styles/playlist.css
@@ -1,7 +1,33 @@
 /***************************************
  *  elements
  ***************************************/
+a, a:hover {
+    color: #000;
+    cursor: default;
+    text-decoration: none;
+}
 
+audio {
+    height: 2rem;
+    width: 16rem;
+}
+
+button {
+    border-radius: 5px;
+}
+
+input[type='radio'] {
+    margin-top: 10px;
+    margin-bottom: 20px;
+}
+
+label {
+    padding: 3px 10px 5px 3px;
+}
+
+/***************************************
+ *  playlist
+ ***************************************/
  .container {
     padding-bottom: 5%;
 }
@@ -33,27 +59,42 @@
     font-weight: 800;
 }
 
-audio {
-    height: 2rem;
-    width: 16rem;
-}
-
+/***************************************
+ *  save playlist form
+ ***************************************/
 .save-playlist-form {
-    position: fixed;
-    top: 0;
-    right: -3em;
-    padding: 7% 3% 3% 3%;
-    margin-right: 4%;
-    z-index: 2;
-    background-color: lightgray;
+    background-color: #eeeeee;
+    font-family: "Lato", sans-serif;
+    font-size: 14px;
+    font-weight: 400;
     height: 100%;
+    margin-right: 2%;
+    padding: 7% 3% 3% 3%;
+    position: fixed;
+    right: -3em;
+    top: 0;
     width: 30%;
-}
-
-button {
-    border-radius: 5px;
+    z-index: 2;
 }
 
 .required {
     color: red;
+}
+
+.save-playlist-btn {
+    border: none;
+    border-width: 0;
+    margin-top: 5px;
+}
+
+.save-playlist-btn:hover {
+    background: #1DB954;
+}
+
+.save-playlist-form h2 {
+    font-size: 24px;
+}
+
+#playlist-name {
+    margin-top: 10px;
 }

--- a/styles/playlist.css
+++ b/styles/playlist.css
@@ -93,6 +93,7 @@ label {
 
 .save-playlist-form h2 {
     font-size: 24px;
+    padding-bottom: 10px;
 }
 
 #playlist-name {

--- a/views/playlist.html
+++ b/views/playlist.html
@@ -77,12 +77,6 @@
 
   <!-- playlist
     =========================================================================== -->
-  <section>
-    <div id="title">
-      <h1 style="text-align:center;">Playlist</h1>
-    </div>
-  </section>
-
   <div>
     <div class="container">
         {{ #playlist }}
@@ -106,20 +100,20 @@
         {{ /playlist }}
 
     <div class="save-playlist-form">
-        <h2>Save Playlist to Your Spotify Account</h2>
+        <h2>Save Playlist to Spotify</h2>
         <form action="/save_playlist" method="get">
           <div>
             <label for="playlist_name">Playlist Name:<span class="required">*</span></label>
             <input type="text" id="playlist_name" name="playlist_name" required>
           </div>
           <div>
-            <label for="private">Private</label>
             <input type="radio" id="private" name="settings" value="private" checked="checked">
-            <label for="public">Public</label>
+            <label for="private">Private</label>
             <input type="radio" id="public" name="settings" value="public">
+            <label for="public">Public</label>
           </div>
           <div>
-            <button type="submit">Save Playlist</button>
+            <button type="submit" class="btn btn-dark save-playlist-btn">Save Playlist</button>
           </div>
         </form>
         </div>

--- a/views/playlist.html
+++ b/views/playlist.html
@@ -54,7 +54,7 @@
   <!-- navbar
     =========================================================================== -->
     <div>
-      <nav class="navbar navbar-expand-md navbar-light navbar-custom">
+      <nav class="navbar navbar-light navbar-custom">
           <a href="/" class="navbar-left">
             <h1>H & C</h1>
           </a>


### PR DESCRIPTION
## Overview
Builds on css for current playlist page. In short, does the following: 

(_Please feel free to make additional updates to the page, or to nix any of my suggestions!_)

- Removes "Playlist" title, since the playlist speaks for itself. Additionally, the playlist title was centered but the playlist was shown on the left. Felt like it looked a little odd after we added the `save playlist` form on the right.

- Removes white gap on the right of the page by adjusting right margin.

- Collapses navbar so the "Home" and "About" links do not distract from the save playlist form.

- Changes `playlist.css` to update form button, button hover, and spacing. 

- Reorganizes `playlist.css` file into sections.

**Updated css:**
<img width="472" alt="Screen Shot 2019-06-03 at 2 05 27 PM" src="https://user-images.githubusercontent.com/23347186/58834664-cab17a80-8608-11e9-82c8-9e0c73635304.png">

**Original css:**
<img width="490" alt="Screen Shot 2019-06-03 at 2 07 28 PM" src="https://user-images.githubusercontent.com/23347186/58834756-f9c7ec00-8608-11e9-94c4-473874b0c401.png">